### PR TITLE
Remove awk from list of packages to be installed

### DIFF
--- a/zookeeper.json
+++ b/zookeeper.json
@@ -69,7 +69,7 @@
         "echo === System Packages ===",
         "echo 'deb http://ftp.debian.org/debian jessie-backports main contrib non-free' | sudo tee /etc/apt/sources.list.d/backports.list > /dev/null",
         "sudo apt-get -qq update",
-        "sudo apt-get -y -qq install --no-install-recommends apt-transport-https apt-show-versions bash-completion logrotate ntp ntpdate htop vim wget curl dbus bmon nmon parted awk wget curl sudo rsyslog ethtool unzip zip telnet tcpdump strace tar libyaml-0-2 lsb-base lsb-release xfsprogs sysfsutils",
+        "sudo apt-get -y -qq install --no-install-recommends apt-transport-https apt-show-versions bash-completion logrotate ntp ntpdate htop vim wget curl dbus bmon nmon parted wget curl sudo rsyslog ethtool unzip zip telnet tcpdump strace tar libyaml-0-2 lsb-base lsb-release xfsprogs sysfsutils",
         "sudo apt-get -y -qq --purge autoremove",
         "sudo apt-get autoclean",
         "sudo apt-get clean",


### PR DESCRIPTION
Error when attempting to run packer build: Package 'awk' has no installation candidate

Removing awk from list of packages allows script to complete.